### PR TITLE
Extend scope of node quality evaluation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2024-08-23
+
+- Consider non-standard ports bad
+- Consider connection times during node quality check
+  - IPv4, IPv6 and CJDNS: Bitcoin Core defaults to a [5s timeout][bitcoind clearnet
+    timeout] for these networks. Since responsive seed nodes are preferred, this
+    threshold is reduced by 50%.
+  - Onion and I2P: Bitcoin Core defaults to a [20s timeout][bitcoind socks5 timeout] for
+    socks5 connections. Since Onion and I2P network performance are prone to variations
+    (intraday fluctuations caused by usage profiles during working ours of different
+    geographic regions, attacks on the networks, etc.), connection times are granted 20%
+    of slack.
+
 ## [1.1.1] - 2024-08-19
 
 - Fix: change column order of blocks and services in `FormattedOutputWriter`
@@ -18,3 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2024-08-02
 
 - Initial release
+
+[bitcoind clearnet timeout]: https://github.com/bitcoin/bitcoin/blob/55d663cb15151773cd043fc9535d6245f8ba6c99/src/netbase.h#L26
+[bitcoind socks5 timeout]: https://github.com/bitcoin/bitcoin/blob/bc87ad98543299e1990ee1994d0653df3ac70093/src/netbase.cpp#L40C27-L40C48

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "seed-exporter"
-version = "1.1.1"
+version = "1.2.0"
 description = "Export viable seeds from data generated with p2p-crawler"
 authors = ["virtu <virtu@cryptic.to>"]
 license = "MIT"

--- a/src/seed_exporter/input/columns.py
+++ b/src/seed_exporter/input/columns.py
@@ -16,3 +16,4 @@ class InputColumns:
     BLOCKS: ClassVar[str] = "latest_block"
     VERSION: ClassVar[str] = "version"
     USER_AGENT: ClassVar[str] = "user_agent"
+    CONNECTION_TIME: ClassVar[str] = "time_connect"


### PR DESCRIPTION
- Consider non-standard ports bad
- Consider connection times during node quality check
  - IPv4, IPv6 and CJDNS: Bitcoin Core defaults to a [5s timeout][bitcoind clearnet
    timeout] for these networks. Since responsive seed nodes are preferred, this
    threshold is reduced by 50%.
  - Onion and I2P: Bitcoin Core defaults to a [20s timeout][bitcoind socks5 timeout] for
    socks5 connections. Since Onion and I2P network performance are prone to variations
    (intraday fluctuations caused by usage profiles during working ours of different
    geographic regions, attacks on the networks, etc.), connection times are granted 20%
    of slack.

[bitcoind clearnet timeout]: https://github.com/bitcoin/bitcoin/blob/55d663cb15151773cd043fc9535d6245f8ba6c99/src/netbase.h#L26
[bitcoind socks5 timeout]: https://github.com/bitcoin/bitcoin/blob/bc87ad98543299e1990ee1994d0653df3ac70093/src/netbase.cpp#L40C27-L40C48
