### PR TITLE
Fix service column bug and collect and output evaluation statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2024-08-23
+
+- Fix bug where wrong column was used for node service data
+- Collect and output statistics on node evaluation results
+
 ## [1.2.0] - 2024-08-23
 
 - Consider non-standard ports bad

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "seed-exporter"
-version = "1.2.0"
+version = "1.2.1"
 description = "Export viable seeds from data generated with p2p-crawler"
 authors = ["virtu <virtu@cryptic.to>"]
 license = "MIT"

--- a/src/seed_exporter/input/columns.py
+++ b/src/seed_exporter/input/columns.py
@@ -17,3 +17,4 @@ class InputColumns:
     VERSION: ClassVar[str] = "version"
     USER_AGENT: ClassVar[str] = "user_agent"
     CONNECTION_TIME: ClassVar[str] = "time_connect"
+    HANDSHAKE_SUCCESSFUL: ClassVar[str] = "handshake_successful"


### PR DESCRIPTION
- Fix bug accidentally introduced in 1.2.0 where code was using the port column as input for the service bits which lead to zero good I2P nodes (because they use port zero)
- Collect statistics about particular rejection reasons when evaluating nodes; output said stats:

```text
2024-08-23T09:26:10Z | INFO     | Network   Total   Good  Share   Port  Services  Version  Blocks  Timeout  Reliability
2024-08-23T09:26:10Z | INFO     | ipv4      12143   4563  37.6%    352      1601        2     452        0         5173
2024-08-23T09:26:10Z | INFO     | ipv6       5380   1208  22.5%     66      1678        0     107        2         2319
2024-08-23T09:26:10Z | INFO     | onion     15507  11102  71.6%      1       539        0      36      434         3395
2024-08-23T09:26:10Z | INFO     | i2p        2489   1589  63.8%      0        92        0       6       10          792
2024-08-23T09:26:10Z | INFO     | cjdns        12      8  66.7%      0         1        0       0        0            3
```